### PR TITLE
fix issues with ansi colours

### DIFF
--- a/bin/bottled-ember
+++ b/bin/bottled-ember
@@ -17,6 +17,7 @@ const {
 } = require('fs');
 
 const { join } = require('path');
+const stripAnsi = require('strip-ansi');
 
 program
   .name('Bottled Ember')
@@ -77,7 +78,7 @@ async function run() {
     initCommand.stdout.setEncoding('utf8');
 
     initCommand.stdout.on("data", (data) => {
-      if(data.includes("Overwrite package.json?")) {
+      if(data.includes(stripAnsi("Overwrite package.json?"))) {
         initCommand.stdin.write("y\n");
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "commander": "^10.0.0",
         "execa": "^6.1.0",
-        "find-cache-dir": "^3.3.2"
+        "find-cache-dir": "^3.3.2",
+        "strip-ansi": "^6.0.0"
       },
       "bin": {
         "bottled-ember": "bin/bottled-ember"
@@ -38,7 +39,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1150,7 +1150,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -1346,8 +1345,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -2127,7 +2125,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "commander": "^10.0.0",
     "execa": "^6.1.0",
-    "find-cache-dir": "^3.3.2"
+    "find-cache-dir": "^3.3.2",
+    "strip-ansi": "^6.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
So apparently bottled ember never worked on terminals that supported colours, who knew 🤷 

it was a simple enough fix once I figured out that you can't compare stdout with a normal string when it has colours in it, you need to strip them out first 👍 