### PR TITLE
Allow you to configure Fastboot dependencies

### DIFF
--- a/bin/bottled-ember.js
+++ b/bin/bottled-ember.js
@@ -7,9 +7,7 @@ const { program } = require('commander');
 const {
   existsSync,
   writeFileSync,
-  rmSync,
   symlinkSync,
-  renameSync,
   lstatSync,
   rmdirSync,
   readlinkSync,
@@ -18,6 +16,7 @@ const {
 const { join } = require('path');
 
 const generateApp = require('../lib/generateApp');
+const customiseApp = require('../lib/customiseApp');
 
 program
   .name('Bottled Ember')
@@ -74,79 +73,7 @@ async function run() {
       console.log('skipping installing dependencies 🤖');
     }
 
-    console.log('customising bottled-ember app 🤖');
-
-    await rmSync(join(cacheDir, 'app/templates/application.hbs'));
-
-    await renameSync(
-      join(cacheDir, 'config/environment.js'),
-      join(cacheDir, 'config/old-environment.js')
-    );
-
-    await writeFileSync(
-      join(cacheDir, 'config/environment.js'),
-      `const oldEnvironment = require('./old-environment');
-
-    module.exports = function(environment) {
-      const ENV = oldEnvironment(environment);
-
-      try {
-        const newEnvironment = require('${join(process.cwd(), 'config')}');
-
-        const newEnv = newEnvironment(environment);
-
-        return {
-          ...ENV,
-          ...newEnv,
-        }
-      } catch {
-        return ENV;
-      }
-    }`
-    );
-
-    await rmSync(join(cacheDir, 'ember-cli-build.js'));
-
-    await writeFileSync(
-      join(cacheDir, 'ember-cli-build.js'),
-      `'use strict';
-
-      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-      const mergeTrees = require('broccoli-merge-trees');
-      const { join } = require('path');
-      const { existsSync } = require('fs');
-      let buildConfig = {}
-
-      try {
-        const localConfig = require('${join(process.cwd(), 'config')}');
-
-        if (localConfig['ember-cli-build']) {
-          buildConfig = localConfig['ember-cli-build'];
-        }
-      } catch {
-        // do nothing
-      }
-
-      let trees = {};
-
-      // todo make no-overlay work at runtime so you don't need to clear cache
-      if (${options.overlay ? true : false} && existsSync(join('${process.cwd()}', 'app'))) {
-        trees.app = mergeTrees([join(__dirname, 'app'), join('${process.cwd()}', 'app')], { overwrite: true })
-      }
-
-      if (${options.overlay ? true : false} && existsSync(join('${process.cwd()}', 'tests'))) {
-        trees.tests = mergeTrees([join(__dirname, 'tests'), join('${process.cwd()}', 'tests')], { overwrite: true })
-      }
-
-      module.exports = function (defaults) {
-        let app = new EmberApp({
-          ...defaults,
-          trees,
-        }, buildConfig);
-        return app.toTree();
-      };
-`
-    );
+    customiseApp(cacheDir, options);
 
     console.log('installing linking your local app 🤖');
 

--- a/lib/customiseApp.js
+++ b/lib/customiseApp.js
@@ -1,0 +1,79 @@
+const { rmSync, renameSync, writeFileSync } = require('fs');
+const { join } = require('path');
+
+module.exports = async function customiseApp(cacheDir, options) {
+  console.log('customising bottled-ember app 🤖');
+
+  await rmSync(join(cacheDir, 'app/templates/application.hbs'));
+
+  await renameSync(
+    join(cacheDir, 'config/environment.js'),
+    join(cacheDir, 'config/old-environment.js')
+  );
+
+  await writeFileSync(
+    join(cacheDir, 'config/environment.js'),
+    `const oldEnvironment = require('./old-environment');
+
+  module.exports = function(environment) {
+    const ENV = oldEnvironment(environment);
+
+    try {
+      const newEnvironment = require('${join(process.cwd(), 'config')}');
+
+      const newEnv = newEnvironment(environment);
+
+      return {
+        ...ENV,
+        ...newEnv,
+      }
+    } catch {
+      return ENV;
+    }
+  }`
+  );
+
+  await rmSync(join(cacheDir, 'ember-cli-build.js'));
+
+  await writeFileSync(
+    join(cacheDir, 'ember-cli-build.js'),
+    `'use strict';
+
+    const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+    const mergeTrees = require('broccoli-merge-trees');
+    const { join } = require('path');
+    const { existsSync } = require('fs');
+    let buildConfig = {}
+
+    try {
+      const localConfig = require('${join(process.cwd(), 'config')}');
+
+      if (localConfig['ember-cli-build']) {
+        buildConfig = localConfig['ember-cli-build'];
+      }
+    } catch {
+      // do nothing
+    }
+
+    let trees = {};
+
+    // todo make no-overlay work at runtime so you don't need to clear cache
+    if (${options.overlay ? true : false} && existsSync(join('${process.cwd()}', 'app'))) {
+      trees.app = mergeTrees([join(__dirname, 'app'), join('${process.cwd()}', 'app')], { overwrite: true })
+    }
+
+    if (${options.overlay ? true : false} && existsSync(join('${process.cwd()}', 'tests'))) {
+      trees.tests = mergeTrees([join(__dirname, 'tests'), join('${process.cwd()}', 'tests')], { overwrite: true })
+    }
+
+    module.exports = function (defaults) {
+      let app = new EmberApp({
+        ...defaults,
+        trees,
+      }, buildConfig);
+      return app.toTree();
+    };
+`
+  );
+  console.log('finished customising bottled-ember app 🤖');
+}

--- a/lib/customiseApp.js
+++ b/lib/customiseApp.js
@@ -1,4 +1,4 @@
-const { rmSync, renameSync, writeFileSync } = require('fs');
+const { rmSync, renameSync, writeFileSync, readFileSync, write } = require('fs');
 const { join } = require('path');
 
 module.exports = async function customiseApp(cacheDir, options) {
@@ -75,5 +75,21 @@ module.exports = async function customiseApp(cacheDir, options) {
     };
 `
   );
+
+  try {
+    const customConfig = require(join(process.cwd(), 'config'));
+
+    // if we have fastbootDependencies then we write them to the package.json
+    if(customConfig.fastbootDependencies) {
+      const cacheJSON = JSON.parse(readFileSync(join(cacheDir, 'package.json')));
+
+      cacheJSON.fastbootDependencies = customConfig.fastbootDependencies;
+
+      writeFileSync(join(cacheDir, 'package.json'), JSON.stringify(cacheJSON, null, 2));
+    }
+  } catch {
+    // ignore
+  }
+
   console.log('finished customising bottled-ember app 🤖');
 }

--- a/test/custom-config.mjs
+++ b/test/custom-config.mjs
@@ -1,0 +1,50 @@
+import { execaNode } from 'execa';
+import tmp from 'tmp';
+import { join, dirname } from 'path';
+import { expect } from 'chai';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let tmpobj;
+
+describe("custom config file", function() {
+
+  // 5 mins timeout
+  this.timeout(5 * 60 * 1000);
+
+
+  beforeEach(function() {
+    tmpobj = tmp.dirSync({
+      unsafeCleanup: true,
+    });
+  })
+
+  afterEach(function() {
+    tmpobj.removeCallback();
+  })
+
+  it.only('can read fastbootDependencies', async function() {
+    const cwd = join(tmpobj.name, 'testing');
+
+    mkdirSync(cwd, {recursive: true});
+
+    writeFileSync(join(cwd, 'package.json'), '{"name": "face"}');
+    writeFileSync(join(cwd, 'config.js'), `module.exports.fastbootDependencies = ['face'];`);
+
+    await execaNode(join(__dirname, '..', 'bin', 'bottled-ember'), ['--no-overlay', '--ember-version', '4.12'], {
+      cwd,
+      env: {
+        BOTTLED_SKIP_DEPENDENCIES: 'true',
+        BOTTLED_SKIP_COMMAND: 'true',
+      },
+      stderr: 'inherit',
+      stdout: 'inherit',
+    });
+
+    const generatedJson = JSON.parse(readFileSync(join(cwd, 'node_modules', '.cache', 'bottled-ember-4-12-default', 'package.json'), 'utf8'));
+
+    expect(generatedJson.fastbootDependencies).to.deep.equal(['face']);
+  });
+})


### PR DESCRIPTION
because fastbootDependencies needs to be defined in your package.json we need to have a way to pass them for the bottled-ember process 👍 